### PR TITLE
feat: 시뮬레이션 상황 리스트 UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,10 +82,6 @@ dependencies {
     ksp(libs.androidx.room.room.compiler)
     implementation(libs.androidx.room.ktx) // Kotlin Extensions and Coroutines support for Room
 
-    //Coil
-    implementation(libs.coil.compose)
-    implementation(libs.coil.network.okhttp)
-
     // Timber for logging
     implementation(libs.timber)
 

--- a/app/src/main/java/com/saegil/android/navigation/NavGraph.kt
+++ b/app/src/main/java/com/saegil/android/navigation/NavGraph.kt
@@ -5,16 +5,16 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.saegil.notice.notice.NoticeScreen
-import com.saegil.learning.learning.LearningScreen
+import com.saegil.learning.learning_list.LearningListScreen
 import com.saegil.map.map.MapScreen
 import com.saegil.mypage.mypage.MypageScreen
+import com.saegil.notice.notice.NoticeScreen
 
 @Composable
 fun NavGraph(navController: NavHostController, modifier: Modifier) {
     NavHost(navController = navController, startDestination = Screen.Learning.route) {
         composable(Screen.Learning.route) {
-            LearningScreen(
+            LearningListScreen(
                 modifier = modifier
             )
         }

--- a/domain/src/main/java/com/saegil/domain/model/Simulation.kt
+++ b/domain/src/main/java/com/saegil/domain/model/Simulation.kt
@@ -1,0 +1,7 @@
+package com.saegil.domain.model
+
+data class Simulation(
+    val id: Long,
+    val name: String,
+    val iconImageUrl: String,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ material3Android = "1.3.1"
 firebaseCrashlyticsBuildtools = "3.0.3"
 kotlinSerialization = "2.0.0"
 browser = "1.8.0"
-uiToolingVersion = "1.7.8"
 
 [libraries]
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }

--- a/presentation/learning/build.gradle.kts
+++ b/presentation/learning/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    debugImplementation(libs.ui.tooling)
+    debugImplementation(libs.androidx.ui.tooling)
 
     //Coil
     implementation(libs.coil.compose)

--- a/presentation/learning/build.gradle.kts
+++ b/presentation/learning/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.runtime.android)
     implementation(libs.androidx.ui.tooling.preview.android)
+    implementation(libs.androidx.foundation.layout.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -53,6 +54,13 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    debugImplementation(libs.ui.tooling)
+
+    //Coil
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
 
     implementation(project(":core:designsystem"))
+    implementation(project(":domain"))
+
 }

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
@@ -1,32 +1,22 @@
 package com.saegil.learning.learning
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
 
 @Composable
 fun LearningScreen(
-    modifier : Modifier = Modifier
-//    state: LearningState,
-//    actions: LearningActions
+    state: LearingState,
+//    actions: LearingActions
 ) {
     // TODO UI Rendering
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "학습 화면", fontSize = 24.sp)
-    }
 }
 
 @Composable
-@Preview(name = "Learning")
-private fun LearningScreenPreview() {
+@Preview(name = "Learing")
+private fun LearingScreenPreview() {
     LearningScreen(
-//        state = LearningState(),
-//        actions = LearningActions()
+        state = LearingState(),
+//        actions = LearingActions()
     )
 }
 

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
@@ -13,11 +13,11 @@ class LearningViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val _stateFlow: MutableStateFlow<LearningState> = MutableStateFlow(LearningState())
+    private val _stateFlow: MutableStateFlow<LearingState> = MutableStateFlow(LearingState())
 
-    val stateFlow: StateFlow<LearningState> = _stateFlow.asStateFlow()
+    val stateFlow: StateFlow<LearingState> = _stateFlow.asStateFlow()
 
 
 }
 
-class LearningState
+class LearingState

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
@@ -50,14 +50,20 @@ fun LearningListScreen(
             iconImageUrl = "https://avatars.githubusercontent.com/u/171667914?s=48&v=4"
         ),
     )
-    LearningListScreen(items)
+    LearningListScreen(
+        items = items,
+        modifier = modifier
+    )
 }
 
 
 @Composable
-internal fun LearningListScreen(items: List<Simulation>) {
+internal fun LearningListScreen(
+    items: List<Simulation>,
+    modifier: Modifier = Modifier
+) {
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
 
     ) {

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
@@ -2,34 +2,18 @@ package com.saegil.learning.learning_list
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
-import coil3.request.crossfade
 import com.saegil.designsystem.theme.SaegilAndroidTheme
-import com.saegil.designsystem.theme.h3
 import com.saegil.domain.model.Simulation
+import com.saegil.learning.learning_list.components.SimulationItem
 
 @Composable
 fun LearningListScreen(
@@ -74,7 +58,7 @@ internal fun LearningListScreen(
         ) {
 
             items(items) { item ->
-                SimulationItem(item) // 단일 항목으로 전달
+                SimulationItem(item)
             }
         }
     }
@@ -82,60 +66,10 @@ internal fun LearningListScreen(
 }
 
 
-@Composable
-fun SimulationItem(item: Simulation) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(72.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-
-            ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 4.dp
-        )
-    ) {
-        Row(
-            modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 18.dp, bottom = 16.dp)
-        ) {
-            Text(
-                text = item.name,
-                style = MaterialTheme.typography.h3,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(item.iconImageUrl)
-                    .crossfade(true)
-                    .build(),
-//                        placeholder = painterResource(R.drawable), // 로딩 중 이미지
-//                        error = painterResource(R.drawable.error), // 에러 시 이미지
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
-
-
-        }
-    }
-
-
-}
 
 @Composable
 @Preview(name = "Learning")
 private fun LearningScreenPreview() {
-//    LearningScreen(
-////        state = LearningState(),
-////        actions = LearningActions()
-//    )
-
     SaegilAndroidTheme {
         Surface {
             LearningListScreen()

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
@@ -69,8 +69,8 @@ internal fun LearningListScreen(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            contentPadding = PaddingValues(36.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
 
             items(items) { item ->
@@ -87,7 +87,6 @@ fun SimulationItem(item: Simulation) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(8.dp)
             .height(72.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -98,19 +97,16 @@ fun SimulationItem(item: Simulation) {
         )
     ) {
         Row(
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 18.dp, bottom = 16.dp)
         ) {
-            // 텍스트 표시
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.h3,
                 color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(8.dp)
             )
 
             Spacer(modifier = Modifier.weight(1f))
 
-            // 이미지 표시
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(item.iconImageUrl)

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListScreen.kt
@@ -1,0 +1,143 @@
+package com.saegil.learning.learning_list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.saegil.designsystem.theme.SaegilAndroidTheme
+import com.saegil.designsystem.theme.h3
+import com.saegil.domain.model.Simulation
+
+@Composable
+fun LearningListScreen(
+    modifier: Modifier = Modifier
+//    state: LearningState,
+//    actions: LearningActions
+) {
+    val items = listOf(
+        Simulation(
+            id = 1,
+            name = "이름",
+            iconImageUrl = "https://avatars.githubusercontent.com/u/171667914?s=48&v=4"
+
+        ),
+        Simulation(
+            id = 2,
+            name = "이름2",
+            iconImageUrl = "https://avatars.githubusercontent.com/u/171667914?s=48&v=4"
+        ),
+    )
+    LearningListScreen(items)
+}
+
+
+@Composable
+internal fun LearningListScreen(items: List<Simulation>) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+
+            items(items) { item ->
+                SimulationItem(item) // 단일 항목으로 전달
+            }
+        }
+    }
+
+}
+
+
+@Composable
+fun SimulationItem(item: Simulation) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .height(72.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+
+            ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(8.dp)
+        ) {
+            // 텍스트 표시
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.h3,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(8.dp)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 이미지 표시
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(item.iconImageUrl)
+                    .crossfade(true)
+                    .build(),
+//                        placeholder = painterResource(R.drawable), // 로딩 중 이미지
+//                        error = painterResource(R.drawable.error), // 에러 시 이미지
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+
+
+        }
+    }
+
+
+}
+
+@Composable
+@Preview(name = "Learning")
+private fun LearningScreenPreview() {
+//    LearningScreen(
+////        state = LearningState(),
+////        actions = LearningActions()
+//    )
+
+    SaegilAndroidTheme {
+        Surface {
+            LearningListScreen()
+        }
+    }
+}
+

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/LearningListViewModel.kt
@@ -1,0 +1,23 @@
+package com.saegil.learning.learning_list
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class LearningViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val _stateFlow: MutableStateFlow<LearningState> = MutableStateFlow(LearningState())
+
+    val stateFlow: StateFlow<LearningState> = _stateFlow.asStateFlow()
+
+
+}
+
+class LearningState

--- a/presentation/learning/src/main/java/com/saegil/learning/learning_list/components/SimulationItem.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning_list/components/SimulationItem.kt
@@ -1,0 +1,66 @@
+package com.saegil.learning.learning_list.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.saegil.designsystem.theme.h3
+import com.saegil.domain.model.Simulation
+
+@Composable
+fun SimulationItem(item: Simulation) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(72.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+
+            ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 18.dp, bottom = 16.dp)
+        ) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.h3,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(item.iconImageUrl)
+                    .crossfade(true)
+                    .build(),
+//                        placeholder = painterResource(R.drawable), // 로딩 중 이미지
+//                        error = painterResource(R.drawable.error), // 에러 시 이미지
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+        }
+    }
+}


### PR DESCRIPTION
## ⭐️ 변경된 내용
- 시뮬레이션 상황 리스트 화면 UI 구현했습니다.
- 해당 api는 아직 미완이라서 일단 더미데이터로 처리했어요!
- `Learning 피쳐 모듈` 안에 `LearningListScreen`과 `LearningScreen`을 나눠서 폴더링 했습니다. 

## 📌 이 부분은 꼭 봐주세요! (Optional) &  🏞️ 스크린샷 (Optional)
|피그마 | 에뮬레이터 |
|---|---|
![image](https://github.com/user-attachments/assets/87aa618e-ed99-4f35-a51d-ebc08ff14216)|![image](https://github.com/user-attachments/assets/bcd259ed-1573-4316-9c56-dd88bc431d47)|

패딩 맞게 한 것 같은데 뭔가... 느낌이... 사뭇 다르네요... 🥹