### PR TITLE
feat: interceptor를 custom plugin으로 구현

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     implementation(libs.ktor.client.content.negotiation) // JSON 파싱
     implementation(libs.ktor.serialization.kotlinx.json) // kotlinx.serialization 사용
     implementation(libs.ktor.client.serialization)
-    implementation(libs.kotlinx.serialization.json)
 
     //Hilt
     implementation(libs.hilt.android)

--- a/data/src/main/java/com/saegil/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/saegil/data/di/NetworkModule.kt
@@ -14,13 +14,19 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.SIMPLE
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+
 import kotlinx.serialization.json.Json
+import okhttp3.internal.connection.ConnectInterceptor.intercept
 import javax.inject.Singleton
 
 @Module
@@ -37,6 +43,9 @@ object NetworkModule {
             }
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            install(DefaultRequest) {
+                contentType(ContentType.Application.Json)
             }
         }
     }

--- a/data/src/main/java/com/saegil/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/saegil/data/di/NetworkModule.kt
@@ -4,6 +4,9 @@ import com.saegil.data.di.network.ConditionalAuthPlugin
 import com.saegil.data.local.TokenDataSource
 import com.saegil.data.remote.FeedService
 import com.saegil.data.remote.FeedServiceImpl
+import com.saegil.data.remote.HttpRoutes.OAUTH_LOGOUT
+import com.saegil.data.remote.HttpRoutes.OAUTH_VALIDATE_TOKEN
+import com.saegil.data.remote.HttpRoutes.OAUTH_WITHDRAWAL
 import com.saegil.data.remote.MapService
 import com.saegil.data.remote.MapServiceImpl
 import com.saegil.data.remote.OAuthService
@@ -24,7 +27,6 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import io.ktor.http.encodedPath
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import javax.inject.Singleton
@@ -52,11 +54,11 @@ object NetworkModule {
             install(ConditionalAuthPlugin) {
                 tokenProvider = { tokenDataSource.getToken().accessToken }
                 shouldAttach = { request ->
-                    val path = request.url.encodedPath
+                    val path = request.url.toString()
                     path in setOf(
-                        "/api/v1/oauth2/withdrawal",
-                        "/api/v1/oauth2/logout",
-                        "/api/v1/oauth2/validate-token"
+                        OAUTH_LOGOUT,
+                        OAUTH_WITHDRAWAL,
+                        OAUTH_VALIDATE_TOKEN
                     )
                 }
             }

--- a/data/src/main/java/com/saegil/data/di/network/ConditionalAuthPlugin.kt
+++ b/data/src/main/java/com/saegil/data/di/network/ConditionalAuthPlugin.kt
@@ -1,0 +1,39 @@
+package com.saegil.data.di.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpClientPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpRequestPipeline
+import io.ktor.http.HttpHeaders
+import io.ktor.util.AttributeKey
+
+class ConditionalAuthPlugin(
+    private val tokenProvider: suspend () -> String,
+    private val shouldAttach: (HttpRequestBuilder) -> Boolean
+) {
+
+    class Config {
+        lateinit var tokenProvider: suspend () -> String
+        var shouldAttach: (HttpRequestBuilder) -> Boolean = { false }
+
+        fun build() = ConditionalAuthPlugin(tokenProvider, shouldAttach)
+    }
+
+    companion object : HttpClientPlugin<Config, ConditionalAuthPlugin> {
+        override val key = AttributeKey<ConditionalAuthPlugin>("ConditionalAuthPlugin")
+
+        override fun prepare(block: Config.() -> Unit): ConditionalAuthPlugin {
+            return Config().apply(block).build()
+        }
+
+        override fun install(plugin: ConditionalAuthPlugin, scope: HttpClient) {
+            scope.requestPipeline.intercept(HttpRequestPipeline.State) {
+                if (plugin.shouldAttach(context)) { // 이 context가 install에서의 request
+                    val token = plugin.tokenProvider()
+                    context.headers.append(HttpHeaders.Authorization, token)
+                }
+                proceed()
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/saegil/data/remote/OAuthService.kt
+++ b/data/src/main/java/com/saegil/data/remote/OAuthService.kt
@@ -6,6 +6,6 @@ import com.saegil.data.model.ValidateTokenResponse
 interface OAuthService {
     suspend fun loginWithKakao(accessToken: String): TokenProto
     suspend fun validateAccessToken(accessToken: String): ValidateTokenResponse
-    suspend fun requestLogout(accessToken: String, refreshToken: String): Boolean
-    suspend fun requestWithdrawal(accessToken: String, refreshToken: String): Boolean
+    suspend fun requestLogout(refreshToken: String): Boolean
+    suspend fun requestWithdrawal(refreshToken: String): Boolean
 }

--- a/data/src/main/java/com/saegil/data/remote/OAuthServiceImpl.kt
+++ b/data/src/main/java/com/saegil/data/remote/OAuthServiceImpl.kt
@@ -35,14 +35,14 @@ class OAuthServiceImpl @Inject constructor(
         return client.get(OAUTH_VALIDATE_TOKEN).body()
     }
 
-    override suspend fun requestLogout(accessToken: String, refreshToken: String): Boolean {
+    override suspend fun requestLogout(refreshToken: String): Boolean {
         val response = client.post(OAUTH_LOGOUT) {
             setBody(mapOf("refreshToken" to refreshToken))
         }
         return response.status == HttpStatusCode.NoContent
     }
 
-    override suspend fun requestWithdrawal(accessToken: String, refreshToken: String): Boolean {
+    override suspend fun requestWithdrawal(refreshToken: String): Boolean {
         val response = client.post(OAUTH_WITHDRAWAL) {
             setBody(mapOf("refreshToken" to refreshToken))
         }

--- a/data/src/main/java/com/saegil/data/remote/OAuthServiceImpl.kt
+++ b/data/src/main/java/com/saegil/data/remote/OAuthServiceImpl.kt
@@ -9,13 +9,9 @@ import com.saegil.data.remote.HttpRoutes.OAUTH_WITHDRAWAL
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import javax.inject.Inject
@@ -26,7 +22,6 @@ class OAuthServiceImpl @Inject constructor(
 
     override suspend fun loginWithKakao(accessToken: String): TokenProto {
         val response = client.post(OAUTH_LOGIN) {
-            contentType(ContentType.Application.Json)
             setBody(mapOf("accessToken" to accessToken))
         }
         val json = response.body<JsonObject>()
@@ -37,15 +32,11 @@ class OAuthServiceImpl @Inject constructor(
     }
 
     override suspend fun validateAccessToken(accessToken: String): ValidateTokenResponse {
-        return client.get(OAUTH_VALIDATE_TOKEN) {
-            header(HttpHeaders.Authorization, accessToken)
-        }.body()
+        return client.get(OAUTH_VALIDATE_TOKEN).body()
     }
 
     override suspend fun requestLogout(accessToken: String, refreshToken: String): Boolean {
         val response = client.post(OAUTH_LOGOUT) {
-            header(HttpHeaders.Authorization, accessToken)
-            contentType(ContentType.Application.Json)
             setBody(mapOf("refreshToken" to refreshToken))
         }
         return response.status == HttpStatusCode.NoContent
@@ -53,8 +44,6 @@ class OAuthServiceImpl @Inject constructor(
 
     override suspend fun requestWithdrawal(accessToken: String, refreshToken: String): Boolean {
         val response = client.post(OAUTH_WITHDRAWAL) {
-            header(HttpHeaders.Authorization, accessToken)
-            contentType(ContentType.Application.Json)
             setBody(mapOf("refreshToken" to refreshToken))
         }
         return response.status == HttpStatusCode.NoContent

--- a/data/src/main/java/com/saegil/data/repository/OAuthRepositoryImpl.kt
+++ b/data/src/main/java/com/saegil/data/repository/OAuthRepositoryImpl.kt
@@ -34,9 +34,9 @@ class OAuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun requestLogout(accessToken: String, refreshToken: String): Boolean {
+    override suspend fun requestLogout(refreshToken: String): Boolean {
         return try {
-            if (oAuthService.requestLogout(accessToken, refreshToken)) {
+            if (oAuthService.requestLogout(refreshToken)) {
                 tokenDataSource.clearToken()
                 true
             } else {
@@ -47,9 +47,9 @@ class OAuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun requestWithdrawal(accessToken: String, refreshToken: String): Boolean {
+    override suspend fun requestWithdrawal(refreshToken: String): Boolean {
         return try {
-            if (oAuthService.requestWithdrawal(accessToken, refreshToken)) {
+            if (oAuthService.requestWithdrawal(refreshToken)) {
                 tokenDataSource.clearToken()
                 true
             } else {

--- a/data/src/main/java/com/saegil/data/repository/OAuthRepositoryImpl.kt
+++ b/data/src/main/java/com/saegil/data/repository/OAuthRepositoryImpl.kt
@@ -61,7 +61,6 @@ class OAuthRepositoryImpl @Inject constructor(
     }
 }
 
-
 fun TokenProto.toDomain() = Token(
     accessToken = this.accessToken,
     refreshToken = this.refreshToken

--- a/domain/src/main/java/com/saegil/domain/repository/OAuthRepository.kt
+++ b/domain/src/main/java/com/saegil/domain/repository/OAuthRepository.kt
@@ -6,6 +6,6 @@ interface OAuthRepository {
     suspend fun loginWithKakao(accessToken: String): Boolean
     suspend fun getToken(): Token
     suspend fun validateAccessToken(accessToken: String): Boolean
-    suspend fun requestLogout(accessToken: String, refreshToken: String): Boolean
-    suspend fun requestWithdrawal(accessToken: String, refreshToken: String): Boolean
+    suspend fun requestLogout(refreshToken: String): Boolean
+    suspend fun requestWithdrawal(refreshToken: String): Boolean
 }

--- a/domain/src/main/java/com/saegil/domain/usecase/LogoutUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/LogoutUseCase.kt
@@ -7,5 +7,5 @@ import javax.inject.Inject
 class LogoutUseCase @Inject constructor(
     private val oAuthRepository: OAuthRepository
 ) {
-    suspend operator fun invoke(token: Token) = oAuthRepository.requestLogout(token.accessToken, token.refreshToken)
+    suspend operator fun invoke(token: Token) = oAuthRepository.requestLogout(token.refreshToken)
 }

--- a/domain/src/main/java/com/saegil/domain/usecase/WithdrawalUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/WithdrawalUseCase.kt
@@ -7,5 +7,5 @@ import javax.inject.Inject
 class WithdrawalUseCase @Inject constructor(
     private val oAuthRepository: OAuthRepository
 ) {
-    suspend operator fun invoke(token: Token) = oAuthRepository.requestWithdrawal(token.accessToken, token.refreshToken)
+    suspend operator fun invoke(token: Token) = oAuthRepository.requestWithdrawal(token.refreshToken)
 }


### PR DESCRIPTION
## ⭐️ 변경된 내용
resolved #42 
+ interceptor를 custom plugin을 구현해서 그것을 install하는 방식으로 구현했습니다.
+ 최종적으로 사용되지 않는 파라미터인 `accessToken`을 지웠습니다.
+ 커스텀플러그인 설명
이 부분이 `ConditionalAuthPlugin`의 `prepare`에서의 `block`입니다.
```
{
    tokenProvider = { tokenDataSource.getToken().accessToken }
    shouldAttach = { request ->
        val path = request.url.encodedPath
        path in setOf(
            "/api/v1/oauth2/withdrawal",
            "/api/v1/oauth2/logout",
            "/api/v1/oauth2/validate-token"
        )
    }
}
```
이거로 본격적인 설치 이전에 `prepare`에서 `Config`의 인스턴스를 만들고 `build`를 통해 `ConditionalAuthPlugin`인스턴스를 생성합니다.
```
class Config {
    lateinit var tokenProvider: suspend () -> String
    var shouldAttach: (HttpRequestBuilder) -> Boolean = { false }

    fun build() = ConditionalAuthPlugin(tokenProvider, shouldAttach)
}
```
그 다음 `install`로 본격적인 설치가 됩니다.
```
override fun install(plugin: ConditionalAuthPlugin, scope: HttpClient) {
    scope.requestPipeline.intercept(HttpRequestPipeline.State) {
        if (plugin.shouldAttach(context)) { // 이 context가 install에서의 request
            val token = plugin.tokenProvider()
            context.headers.append(HttpHeaders.Authorization, token)
        }
        proceed()
    }
}
```
이 부분이 비로소 실행되구요 여기서 `context`가 `HttpRequestBuilder`인 `block`에서의 `request`입니다..
이거로 조건을 확인하고 그걸 통해 헤더를 붙일지 결정합니다.

또한 보면 경로를 그냥 `block`에서 `set`으로 넣었는데 어차피 `install`이 `HttpClient`인스턴스가 생성될 때 처음 한번만 실행되는 거라 별도로 빼놓으면 불필요한 리소스를 먹는 것 같아서 그냥 아예 `install`할때 한번만 넘기면 되도록 바로 집어넣었습니다.

## 📌 이 부분은 꼭 봐주세요! (Optional)



## 🏞️ 스크린샷 (Optional)