### PR TITLE
hotfix: 앱 설치 후 앱 아이콘이 생기지 않는 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.saegil.android"
         minSdk = 24
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["NAVER_CLIENT_ID"] = properties.getProperty("naver_client_id")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.saegil.android"
         minSdk = 24
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["NAVER_CLIENT_ID"] = properties.getProperty("naver_client_id")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,17 +25,21 @@
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.SaegilAndroid">
+            <!-- 앱 아이콘을 위한 런처 인텐트 필터 -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
+            </intent-filter>
+
+            <!-- 딥링크를 위한 인텐트 필터 -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:scheme="saegil"
-                    android:host="callback"/>
-
+                    android:host="callback" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Saegil-Android</string>
+    <string name="app_name">새길</string>
 </resources>


### PR DESCRIPTION
## ⭐️ 변경된 내용
매니페스트에서 인텐트 필터가 꼬여서 생긴 문제였습니다.
```
    <!-- 앱 아이콘을 위한 런처 인텐트 필터 -->
    <intent-filter>
        <action android:name="android.intent.action.MAIN" />
        <category android:name="android.intent.category.LAUNCHER" />
    </intent-filter>

    <!-- 딥링크를 위한 인텐트 필터 -->
    <intent-filter>
        <action android:name="android.intent.action.VIEW" />
        <category android:name="android.intent.category.DEFAULT" />
        <category android:name="android.intent.category.BROWSABLE" />
        <data
            android:scheme="saegil"
            android:host="callback" />
    </intent-filter>
```
이렇게 분리해주니 되도라구요.

- 설치 시 생기는 앱 이름 "새길" 한글명으로 바꿨습니다
![image](https://github.com/user-attachments/assets/437c1307-e851-4f1d-a159-4b4308ee30c0)

- 버전코드2, 버전네임 1.0.1로 올렸습니다
- 카카오 릴리즈 해시키 문제로 업데이트 다시 올려서 3, 1.0.2로 올렸습니다.

## 📌 이 부분은 꼭 봐주세요! (Optional)



## 🏞️ 스크린샷 (Optional)