### PR TITLE
fix: 지도 api 호출 최적화

### DIFF
--- a/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
+++ b/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
@@ -230,15 +230,6 @@ private fun calculateDistance(location1: LatLng, location2: LatLng): Double {
 object MapConstants {
     const val EARTH_RADIUS_KM = 6371.0
     const val THRESHOLD = 0.1
-
-    // 줌 레벨 기준
-    const val ZOOM_CLOSE = 15.0   // 500m
-    const val ZOOM_MEDIUM = 13.0  // 1km
-    const val ZOOM_FAR = 0.0      // 5km (기본값)
-
-    const val RADIUS_CLOSE = 0.5    // 단위: km
-    const val RADIUS_MEDIUM = 1.0
-    const val RADIUS_FAR = 5.0
 }
 
 @Composable

--- a/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
+++ b/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
@@ -32,6 +32,8 @@ import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.saegil.designsystem.component.SaegilTitleText
 import com.saegil.domain.model.Organization
+import com.saegil.map.map.MapConstants.EARTH_RADIUS_KM
+import com.saegil.map.map.MapConstants.THRESHOLD
 import com.saegil.map.map.components.OrganizationBottomSheet
 import com.saegil.map.map.components.SelectedMarker
 import com.saegil.map.map.components.UnselectedMarker
@@ -40,6 +42,7 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+
 
 @Composable
 fun MapScreen(
@@ -50,9 +53,6 @@ fun MapScreen(
     val cameraPositionState = rememberCameraPositionState()
     var selectedOrganization by remember { mutableStateOf<Organization?>(null) }
     var lastLocation by remember { mutableStateOf<LatLng?>(null) }
-
-    val ZOOM_LEVEL = 15.0
-    val THRESHOLD = 0.1
 
 
     LaunchedEffect(cameraPositionState.position) {
@@ -207,14 +207,7 @@ internal fun MapScreen(
     }
 }
 
-@Composable
-@Preview(name = "Map")
-private fun MapScreenPreview() {
-    MapScreen()
-}
-
 private fun calculateDistance(location1: LatLng, location2: LatLng): Double {
-    val R = 6371.0 // Earth's radius in kilometers
     val lat1 = Math.toRadians(location1.latitude)
     val lat2 = Math.toRadians(location2.latitude)
     val dLat = Math.toRadians(location2.latitude - location1.latitude)
@@ -224,6 +217,18 @@ private fun calculateDistance(location1: LatLng, location2: LatLng): Double {
             cos(lat1) * cos(lat2) *
             sin(dLon / 2) * sin(dLon / 2)
     val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-    return R * c
+    return EARTH_RADIUS_KM * c
+}
+
+object MapConstants {
+    const val EARTH_RADIUS_KM = 6371.0
+    const val ZOOM_LEVEL = 15.0
+    const val THRESHOLD = 0.1
+}
+
+@Composable
+@Preview(name = "Map")
+private fun MapScreenPreview() {
+    MapScreen()
 }
 

--- a/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
+++ b/presentation/map/src/main/java/com/saegil/map/map/MapScreen.kt
@@ -53,6 +53,8 @@ fun MapScreen(
     val cameraPositionState = rememberCameraPositionState()
     var selectedOrganization by remember { mutableStateOf<Organization?>(null) }
     var lastLocation by remember { mutableStateOf<LatLng?>(null) }
+    var lastZoomLevel by remember { mutableStateOf<Double?>(null) }
+
 
 
     LaunchedEffect(cameraPositionState.position) {
@@ -60,6 +62,7 @@ fun MapScreen(
             cameraPositionState.position.target.latitude,
             cameraPositionState.position.target.longitude
         )
+        val currentZoomLevel = cameraPositionState.position.zoom
 
         if (lastLocation == null || calculateDistance(
                 lastLocation!!,
@@ -72,6 +75,10 @@ fun MapScreen(
             )
             viewModel.updateZoomLevel(cameraPositionState.position.zoom)
             lastLocation = currentLocation
+        }
+
+        if (lastZoomLevel != currentZoomLevel) {
+            viewModel.updateZoomLevel(currentZoomLevel)
         }
     }
 
@@ -222,8 +229,16 @@ private fun calculateDistance(location1: LatLng, location2: LatLng): Double {
 
 object MapConstants {
     const val EARTH_RADIUS_KM = 6371.0
-    const val ZOOM_LEVEL = 15.0
     const val THRESHOLD = 0.1
+
+    // 줌 레벨 기준
+    const val ZOOM_CLOSE = 15.0   // 500m
+    const val ZOOM_MEDIUM = 13.0  // 1km
+    const val ZOOM_FAR = 0.0      // 5km (기본값)
+
+    const val RADIUS_CLOSE = 0.5    // 단위: km
+    const val RADIUS_MEDIUM = 1.0
+    const val RADIUS_FAR = 5.0
 }
 
 @Composable

--- a/presentation/map/src/main/java/com/saegil/map/map/MapViewModel.kt
+++ b/presentation/map/src/main/java/com/saegil/map/map/MapViewModel.kt
@@ -1,8 +1,5 @@
 package com.saegil.map.map
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.saegil.domain.usecase.GetMapListUseCase
@@ -28,9 +25,6 @@ class MapViewModel @Inject constructor(
     private val _longitude = MutableStateFlow(0.0)
     private val _radius = MutableStateFlow(500) //500, 1000, 5000 라서 500m를 디폴트로 함
 
-    var zoomLevel: Double by mutableDoubleStateOf(15.0)
-        private set
-
     fun updateLocation(lat: Double, lng: Double) {
         Timber.d("Updating location in ViewModel: lat=$lat, lng=$lng")
         _latitude.value = lat
@@ -39,7 +33,13 @@ class MapViewModel @Inject constructor(
 
     fun updateZoomLevel(zoom: Double) {
         Timber.d("Updating zoom level: $zoom")
-        zoomLevel = zoom
+
+        val radius = when {
+            zoom >= 13.5 -> 500    // 500m 반경
+            zoom >= 11.5 -> 1000    // 1km 반경
+            else -> 5000            // 5km 반경
+        }
+        _radius.value = radius
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/presentation/map/src/main/java/com/saegil/map/map/components/OrganizationBottomSheet.kt
+++ b/presentation/map/src/main/java/com/saegil/map/map/components/OrganizationBottomSheet.kt
@@ -66,7 +66,7 @@ private fun OrganizationContent(
             style = MaterialTheme.typography.h2
         )
         Spacer(modifier = Modifier.height(8.dp))
-        InfoText(modifier = Modifier, "운영시간", organization.name)
+        InfoText(modifier = Modifier, "운영시간", organization.operatingHours) //todo 운영 시간, 전화번호 없음 이슈
         Spacer(modifier = Modifier.height(8.dp))
         InfoText(modifier = Modifier, "전화번호", organization.telephoneNumber)
         Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## ⭐️ 변경된 내용
이전 로직은 위도, 경도가 0.00000000001 이라도 달라지면 api호출을 하도록 구현되어있었습니다. 그 결과 저희 프리티어 ec2가 터져서 서버가 내려가는 문제가 발생하였습니다.

그래서 현실적으로 지도상에서 유의미한 변화가 있을때에 api 재호출을 하도록 수정하였습니다.

1. 실질적인 변화가 있을때만 api 재호출 
- 위도 1도는 약 111km, 경도 1도는 위도에 따라 다르지만 서울 기준으로 약 88.8km입니다. 유의미한 변화를 위해 `직전 위도 경도와 현 위도경도가 약 100m(1km) 정도의 변화가 있을 때만` API를 호출하도록 하도록 함.
2. 줌 레벨에 따라 api 재호출 
- 축적에 따른 api 호출(지도 sdk에서 500m, 1km 등 축적 정도를 클릭하면 api의 파라미터를 변경해서 재 호출하도록 추가 구현)
  - 줌레벨이 각각 5km가 13, 1km가 12, 500km가 9인걸로 when문 돌려서 radius 바뀌면 재호출하도록 

## 📌 이 부분은 꼭 봐주세요! (Optional)



## 🏞️ 스크린샷 (Optional)
[zoomup.webm](https://github.com/user-attachments/assets/dd3d91dc-e2d6-4038-859b-5dcc7acf4fe6)
