### PR TITLE
fix: thread id 활용 및 대화 종료 시 다이알로그 구현

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     //Preferences DataStore/Proto
     implementation(libs.androidx.datastore)
     implementation(libs.protobuf.javalite)
+    implementation(libs.androidx.datastore.preferences)
 
     implementation(project(":domain"))//클린아키텍처 도메인 의존
 }

--- a/data/src/main/java/com/saegil/data/di/DataModule.kt
+++ b/data/src/main/java/com/saegil/data/di/DataModule.kt
@@ -3,27 +3,26 @@ package com.saegil.data.di
 import android.content.Context
 import com.saegil.data.local.TokenDataSource
 import com.saegil.data.local.TokenDataSourceImpl
-import com.saegil.data.remote.AssistantService
 import com.saegil.data.remote.FeedService
 import com.saegil.data.remote.MapService
 import com.saegil.data.remote.OAuthService
 import com.saegil.data.remote.ScenarioService
 import com.saegil.data.remote.SimulationLogService
 import com.saegil.data.remote.TextToSpeechService
-import com.saegil.data.repository.TextToSpeechRepositoryImpl
 import com.saegil.data.remote.UserInfoService
 import com.saegil.data.repository.FeedRepositoryImpl
 import com.saegil.data.repository.MapRepositoryImpl
 import com.saegil.data.repository.OAuthRepositoryImpl
-import com.saegil.data.repository.SimulationLogRepositoryImpl
 import com.saegil.data.repository.ScenarioRepositoryImpl
-import com.saegil.domain.repository.TextToSpeechRepository
+import com.saegil.data.repository.SimulationLogRepositoryImpl
+import com.saegil.data.repository.TextToSpeechRepositoryImpl
 import com.saegil.data.repository.UserInfoRepositoryImpl
 import com.saegil.domain.repository.FeedRepository
 import com.saegil.domain.repository.MapRepository
 import com.saegil.domain.repository.OAuthRepository
 import com.saegil.domain.repository.ScenarioRepository
 import com.saegil.domain.repository.SimulationLogRepository
+import com.saegil.domain.repository.TextToSpeechRepository
 import com.saegil.domain.repository.UserInfoRepository
 import dagger.Module
 import dagger.Provides
@@ -38,6 +37,12 @@ object DataModule {
 
     @Provides
     @Singleton
+    fun provideTokenDataSource(@ApplicationContext context: Context): TokenDataSource {
+        return TokenDataSourceImpl(context)
+    }
+
+    @Provides
+    @Singleton
     fun provideFeedRepository(feedService: FeedService): FeedRepository {
         return FeedRepositoryImpl(feedService)
     }
@@ -46,12 +51,6 @@ object DataModule {
     @Singleton
     fun provideMapRepository(mapService: MapService): MapRepository {
         return MapRepositoryImpl(mapService)
-    }
-
-    @Provides
-    @Singleton
-    fun provideTokenDataSource(@ApplicationContext context: Context): TokenDataSource {
-        return TokenDataSourceImpl(context)
     }
 
     @Provides

--- a/data/src/main/java/com/saegil/data/di/RetrofitNetworkModule.kt
+++ b/data/src/main/java/com/saegil/data/di/RetrofitNetworkModule.kt
@@ -1,6 +1,7 @@
 package com.saegil.data.di
 
 import com.saegil.data.BuildConfig
+import com.saegil.data.local.ThreadPreferencesManager
 import com.saegil.data.remote.AssistantApi
 import com.saegil.data.repository.AssistantRepositoryImpl
 import com.saegil.domain.repository.AssistantRepository
@@ -64,6 +65,10 @@ object RetrofitNetworkModule {
 
     @Provides
     @Singleton
-    fun provideAssistantRepository(api: AssistantApi): AssistantRepository =
-        AssistantRepositoryImpl(api)
+    fun provideAssistantRepository(
+        api: AssistantApi,
+        threadPreferencesManager: ThreadPreferencesManager
+    ): AssistantRepository =
+        AssistantRepositoryImpl(api, threadPreferencesManager)
+
 }

--- a/data/src/main/java/com/saegil/data/local/ThreadPreferences.kt
+++ b/data/src/main/java/com/saegil/data/local/ThreadPreferences.kt
@@ -1,0 +1,6 @@
+package com.saegil.data.local
+
+object ThreadPreferences {
+    const val PREFERENCES_NAME = "thread_preferences"
+    const val KEY_THREAD_ID = "thread_id"
+} 

--- a/data/src/main/java/com/saegil/data/local/ThreadPreferencesManager.kt
+++ b/data/src/main/java/com/saegil/data/local/ThreadPreferencesManager.kt
@@ -1,0 +1,41 @@
+package com.saegil.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = ThreadPreferences.PREFERENCES_NAME
+)
+
+@Singleton
+class ThreadPreferencesManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val threadIdKey = stringPreferencesKey(ThreadPreferences.KEY_THREAD_ID)
+
+    val threadId: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[threadIdKey]
+        }
+
+    suspend fun saveThreadId(threadId: String) {
+        context.dataStore.edit { preferences ->
+            preferences[threadIdKey] = threadId
+        }
+    }
+
+    suspend fun clearThreadId() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(threadIdKey)
+        }
+    }
+} 

--- a/data/src/main/java/com/saegil/data/remote/AssistantApi.kt
+++ b/data/src/main/java/com/saegil/data/remote/AssistantApi.kt
@@ -6,11 +6,13 @@ import retrofit2.Response
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 interface AssistantApi { //todo ktor로 마이그레이션 하기
     @Multipart
     @POST("/api/v1/llm/assistant/upload")
     suspend fun uploadAudio(
-        @Part file: MultipartBody.Part
+        @Part file: MultipartBody.Part,
+        @Query("thread_id") threadId: String? = null
     ): Response<UploadAudioDto>
 }

--- a/data/src/main/java/com/saegil/data/remote/AssistantApi.kt
+++ b/data/src/main/java/com/saegil/data/remote/AssistantApi.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 
-interface AssistantApi {
+interface AssistantApi { //todo ktor로 마이그레이션 하기
     @Multipart
     @POST("/api/v1/llm/assistant/upload")
     suspend fun uploadAudio(

--- a/data/src/main/java/com/saegil/data/remote/AssistantServiceImpl.kt
+++ b/data/src/main/java/com/saegil/data/remote/AssistantServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.saegil.data.remote
 
+import com.saegil.data.local.ThreadPreferencesManager
 import com.saegil.data.model.UploadAudioDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -12,13 +13,17 @@ import io.ktor.http.ContentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.first
 import java.io.File
 import javax.inject.Inject
 
 class AssistantServiceImpl @Inject constructor(
-    private val client: HttpClient
+    private val client: HttpClient,
+    private val threadPreferencesManager: ThreadPreferencesManager
 ) : AssistantService {
     override suspend fun getAssistant(file: File): UploadAudioDto? {
+        val threadId = threadPreferencesManager.threadId.first()
+        
         val response = client.post(HttpRoutes.ASSISTANT) {
             setBody(
                 MultiPartFormDataContent(
@@ -34,8 +39,9 @@ class AssistantServiceImpl @Inject constructor(
                                 append(HttpHeaders.ContentType, "audio/x-m4a")
                             }
                         )
-//                        append("thread_id", "") // 필요 시 추가
-//                        append("provider", "OPENAI") // 필요 시 추가
+                        threadId?.let { id ->
+                            append("thread_id", id)
+                        }
                     }
                 )
             )
@@ -43,7 +49,7 @@ class AssistantServiceImpl @Inject constructor(
                 append(HttpHeaders.Authorization, "Bearer saegil-dev-test-token")
                 append(HttpHeaders.Accept, "application/json")
             }
-            contentType(ContentType.MultiPart.FormData) // 이건 없어도 됩니다. 위에서 자동 설정됨
+            contentType(ContentType.MultiPart.FormData)
         }
         return response.body()
     }

--- a/data/src/main/java/com/saegil/data/repository/AssistantRepositoryImpl.kt
+++ b/data/src/main/java/com/saegil/data/repository/AssistantRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.saegil.data.repository
 
-
+import com.saegil.data.local.ThreadPreferencesManager
 import com.saegil.data.remote.AssistantApi
 import com.saegil.domain.model.UploadAudio
 import com.saegil.domain.repository.AssistantRepository
@@ -10,9 +10,11 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
+import javax.inject.Inject
 
-class AssistantRepositoryImpl(
-    private val api: AssistantApi
+class AssistantRepositoryImpl @Inject constructor(
+    private val api: AssistantApi,
+    private val threadPreferencesManager: ThreadPreferencesManager
 ) : AssistantRepository {
 
     override suspend fun uploadAudio(file: File): Flow<Result<UploadAudio>> = flow {
@@ -39,5 +41,17 @@ class AssistantRepositoryImpl(
         } catch (e: Exception) {
             emit(Result.failure(e))
         }
+    }
+
+    override suspend fun saveThreadId(threadId: String) {
+        threadPreferencesManager.saveThreadId(threadId)
+    }
+
+    override fun getThreadId(): Flow<String?> {
+        return threadPreferencesManager.threadId
+    }
+
+    override suspend fun clearThreadId() {
+        threadPreferencesManager.clearThreadId()
     }
 }

--- a/data/src/main/java/com/saegil/data/repository/AssistantRepositoryImpl.kt
+++ b/data/src/main/java/com/saegil/data/repository/AssistantRepositoryImpl.kt
@@ -17,6 +17,34 @@ class AssistantRepositoryImpl @Inject constructor(
     private val threadPreferencesManager: ThreadPreferencesManager
 ) : AssistantRepository {
 
+    override suspend fun uploadAudio(file: File, threadId: String?): Flow<Result<UploadAudio>> =
+        flow {
+            try {
+                val requestFile = file.asRequestBody("audio/x-m4a".toMediaTypeOrNull())
+                val body = MultipartBody.Part.createFormData("file", file.name, requestFile)
+                val response = api.uploadAudio(file = body, threadId = threadId)
+
+                if (response.isSuccessful) {
+                    response.body()?.let {
+                        emit(Result.success(it.toDomain()))
+                    } ?: emit(Result.failure(Exception("Empty body")))
+                } else {
+                    emit(
+                        Result.failure(
+                            Exception(
+                                "Error: ${response.code()} - ${
+                                    response.errorBody()?.string()
+                                }"
+                            )
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                emit(Result.failure(e))
+            }
+        }
+
+
     override suspend fun uploadAudio(file: File): Flow<Result<UploadAudio>> = flow {
         try {
             val requestFile = file.asRequestBody("audio/x-m4a".toMediaTypeOrNull())

--- a/domain/src/main/java/com/saegil/domain/repository/AssistantRepository.kt
+++ b/domain/src/main/java/com/saegil/domain/repository/AssistantRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 interface AssistantRepository {
+    suspend fun uploadAudio(file: File, threadId: String?): Flow<Result<UploadAudio>>
     suspend fun uploadAudio(file: File): Flow<Result<UploadAudio>>
     suspend fun saveThreadId(threadId: String)
     fun getThreadId(): Flow<String?>

--- a/domain/src/main/java/com/saegil/domain/repository/AssistantRepository.kt
+++ b/domain/src/main/java/com/saegil/domain/repository/AssistantRepository.kt
@@ -5,7 +5,8 @@ import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 interface AssistantRepository {
-    suspend fun uploadAudio(
-        file: File,
-    ): Flow<Result<UploadAudio>>
+    suspend fun uploadAudio(file: File): Flow<Result<UploadAudio>>
+    suspend fun saveThreadId(threadId: String)
+    fun getThreadId(): Flow<String?>
+    suspend fun clearThreadId()
 }

--- a/domain/src/main/java/com/saegil/domain/usecase/ClearThreadIdUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/ClearThreadIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.saegil.domain.usecase
+
+import com.saegil.domain.repository.AssistantRepository
+import javax.inject.Inject
+
+class ClearThreadIdUseCase @Inject constructor(
+    private val assistantRepository: AssistantRepository
+) {
+    suspend operator fun invoke() {
+        assistantRepository.clearThreadId()
+    }
+} 

--- a/domain/src/main/java/com/saegil/domain/usecase/GetThreadIdUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/GetThreadIdUseCase.kt
@@ -1,0 +1,13 @@
+package com.saegil.domain.usecase
+
+import com.saegil.domain.repository.AssistantRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetThreadIdUseCase @Inject constructor(
+    private val assistantRepository: AssistantRepository
+) {
+    suspend operator fun invoke(): Flow<String?> {
+        return assistantRepository.getThreadId()
+    }
+} 

--- a/domain/src/main/java/com/saegil/domain/usecase/SaveThreadIdUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/SaveThreadIdUseCase.kt
@@ -1,0 +1,12 @@
+package com.saegil.domain.usecase
+
+import com.saegil.domain.repository.AssistantRepository
+import javax.inject.Inject
+
+class SaveThreadIdUseCase @Inject constructor(
+    private val assistantRepository: AssistantRepository
+) {
+    suspend operator fun invoke(threadId: String) {
+        assistantRepository.saveThreadId(threadId)
+    }
+} 

--- a/domain/src/main/java/com/saegil/domain/usecase/UploadAudioUseCase.kt
+++ b/domain/src/main/java/com/saegil/domain/usecase/UploadAudioUseCase.kt
@@ -12,4 +12,8 @@ class UploadAudioUseCase @Inject constructor(
     suspend operator fun invoke(file: File): Flow<Result<UploadAudio>> {
         return assistantRepository.uploadAudio(file)
     }
+
+    suspend operator fun invoke(file: File, threadId: String?): Flow<Result<UploadAudio>> {
+        return assistantRepository.uploadAudio(file, threadId)
+    }
 } 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+datastorePreferencesVersion = "1.1.6"
 datastoreVersion = "1.1.5"
 foundationLayoutAndroid = "1.5.0"
 accompanistPermissionsVersion = "0.37.2"
@@ -60,6 +61,7 @@ uiToolingPreviewAndroidVersion = "1.8.0"
 
 [libraries]
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastoreVersion" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferencesVersion" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compiler" }
 androidx-compose-ui-ui = { module = "androidx.compose.ui:ui" }

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -75,7 +74,7 @@ fun LearningScreen(
 
     LaunchedEffect(state) {
         when (state) {
-            is LearningUiState.isUploading -> {
+            is LearningUiState.Uploading -> {
                 while (true) {
                     currentEmotion = CharacterEmotion.NORMAL
                     delay(300)
@@ -84,7 +83,7 @@ fun LearningScreen(
                 }
             }
 
-            is LearningUiState.isRecording -> {
+            is LearningUiState.Recording -> {
                 currentEmotion = CharacterEmotion.WONDER
             }
 
@@ -152,7 +151,7 @@ fun LearningScreen(
 
             when (state) {
 
-                is LearningUiState.isUploading -> {
+                is LearningUiState.Uploading -> {
                     CircularProgressIndicator(
                         modifier = Modifier.padding(top = 100.dp)
                     )
@@ -170,7 +169,7 @@ fun LearningScreen(
                     )
                 }
 
-                LearningUiState.isRecording -> {
+                LearningUiState.Recording -> {
                 }
             }
         }
@@ -200,7 +199,7 @@ fun LearningScreen(
                     )
                 }
 
-                is LearningUiState.isRecording -> {
+                is LearningUiState.Recording -> {
                     RecordButton(
                         isRecording = true,
                         onClick = {

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningUiState.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningUiState.kt
@@ -6,9 +6,9 @@ sealed interface LearningUiState {
 
     data object Idle : LearningUiState
 
-    data object isRecording : LearningUiState
+    data object Recording : LearningUiState
 
-    data object isUploading : LearningUiState
+    data object Uploading : LearningUiState
 
     data class Success(val response: UploadAudio) : LearningUiState
 

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
@@ -5,10 +5,14 @@ import android.content.pm.PackageManager
 import android.media.MediaPlayer
 import android.media.MediaRecorder
 import android.os.Environment
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.saegil.domain.usecase.ClearThreadIdUseCase
 import com.saegil.domain.usecase.DownloadAudioUseCase
+import com.saegil.domain.usecase.GetThreadIdUseCase
+import com.saegil.domain.usecase.SaveThreadIdUseCase
 import com.saegil.domain.usecase.UploadAudioUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -16,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
@@ -26,6 +31,9 @@ class LearningViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val uploadAudioUseCase: UploadAudioUseCase,
     private val downloadAudioUseCase: DownloadAudioUseCase,
+    private val saveThreadIdUseCase: SaveThreadIdUseCase,
+    private val getThreadIdUseCase: GetThreadIdUseCase,
+    private val clearThreadIdUseCase: ClearThreadIdUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<LearningUiState>(LearningUiState.Idle)
@@ -87,13 +95,44 @@ class LearningViewModel @Inject constructor(
                     _uiState.value = LearningUiState.Uploading
 
                     try {
-                        uploadAudioUseCase(file).collect { result ->
-                            result
-                                .onSuccess { dto ->
-                                    _uiState.value = LearningUiState.Success(dto)
-                                    downloadAudio(dto.response)
-                                }
-                                .onFailure { error -> println("실패: ${error.message}") }
+                        val threadId = getThreadId()
+                        Log.d("LearningViewModel", "dld threadId: $threadId")
+                        if (threadId?.isNotEmpty() == true) {
+                            uploadAudioUseCase(
+                                file = file,
+                                threadId = getThreadId()
+                            ).collect { result ->
+                                result
+                                    .onSuccess { dto ->
+                                        _uiState.value = LearningUiState.Success(dto) //응답 받아서
+                                        downloadAudio(dto.response)
+                                        saveThreadId(dto.threadId)
+                                    }
+                                    .onFailure { error ->
+                                        Log.d(
+                                            "LearningViewModel",
+                                            "에러: ${error.message}"
+                                        )
+                                    }
+                            }
+                        } else {
+                            uploadAudioUseCase(
+                                file = file,
+                                threadId = getThreadId()
+                            ).collect { result ->
+                                result
+                                    .onSuccess { dto ->
+                                        _uiState.value = LearningUiState.Success(dto) //응답 받아서
+                                        downloadAudio(dto.response)
+                                        Log.d("LearningViewModel", "threadId: ${threadId}")
+                                    }
+                                    .onFailure { error ->
+                                        Log.d(
+                                            "LearningViewModel",
+                                            "에러: ${error.message}"
+                                        )
+                                    }
+                            }
                         }
                     } catch (e: Exception) {
                         _uiState.value = LearningUiState.Error("파일 업로드 중 오류가 발생했습니다")
@@ -110,6 +149,25 @@ class LearningViewModel @Inject constructor(
         super.onCleared()
         if (_uiState.value == LearningUiState.Recording) {
             stopRecording()
+        }
+    }
+
+    private fun saveThreadId(threadId: String) {
+        viewModelScope.launch {
+            try {
+                saveThreadIdUseCase(threadId)
+            } catch (e: Exception) {
+                _uiState.value = LearningUiState.Error("쓰레드 ID 저장 중 오류가 발생했습니다")
+            }
+        }
+    }
+
+    private suspend fun getThreadId(): String? {
+        return try {
+            getThreadIdUseCase().first() // Flow에서 첫 값을 받아옴
+        } catch (e: Exception) {
+            _uiState.value = LearningUiState.Error("쓰레드 ID를 가져오던 중 오류가 발생했습니다")
+            null
         }
     }
 

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
@@ -60,7 +60,7 @@ class LearningViewModel @Inject constructor(
                 prepare()
                 start()
             }
-            _uiState.value = LearningUiState.isRecording
+            _uiState.value = LearningUiState.Recording
         } catch (e: IOException) {
             _uiState.value = LearningUiState.Error("녹음 시작 중 오류가 발생했습니다")
         }
@@ -84,7 +84,7 @@ class LearningViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 audioFile?.let { file ->
-                    _uiState.value = LearningUiState.isUploading
+                    _uiState.value = LearningUiState.Uploading
 
                     try {
                         uploadAudioUseCase(file).collect { result ->
@@ -108,7 +108,7 @@ class LearningViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        if (_uiState.value == LearningUiState.isRecording) {
+        if (_uiState.value == LearningUiState.Recording) {
             stopRecording()
         }
     }


### PR DESCRIPTION
## ⭐️ 변경된 내용

- 오버로딩을 활용하여 thread가 있을시와 없을시 다형성을 구현하였습니다.

1. 처음 호출시 스레드 아이디 없음
<img width="752" alt="스크린샷 2025-05-20 오후 5 20 08" src="https://github.com/user-attachments/assets/357ec67e-41f5-44a7-9e9f-7b212b6f63df" />

2. 스레드 아이디 받음
<img width="1293" alt="스크린샷 2025-05-20 오후 5 20 42" src="https://github.com/user-attachments/assets/4e656be4-6e58-4c1c-9e0c-f38876e60071" />
3. 이후 호출부터는 스레드 아이디를 query로 함께 넣음

4. 물리 뒤로가기 버튼 및 상단바에 <- 누를시 다이알로그 띄움 (대화 종료) 

5. 대화 종료시 로컬(dataStore)에 있는 스레드 아이디 삭제


## 📌 이 부분은 꼭 봐주세요! (Optional)



## 🏞️ 스크린샷 (Optional)