### PR TITLE
feat: 학습 대화 음성 텍스트 싱크 맞추기

### DIFF
--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
@@ -90,8 +90,8 @@ class LearningViewModel @Inject constructor(
                         uploadAudioUseCase(file).collect { result ->
                             result
                                 .onSuccess { dto ->
-                                    _uiState.value = LearningUiState.Success(dto)
                                     downloadAudio(dto.response)
+                                    _uiState.value = LearningUiState.Success(dto)
                                 }
                                 .onFailure { error -> println("실패: ${error.message}") }
                         }
@@ -113,19 +113,17 @@ class LearningViewModel @Inject constructor(
         }
     }
 
-    private fun downloadAudio(text: String) {
-        viewModelScope.launch {
-            try {
-                downloadAudioUseCase(text)
-                    .catch {
-                        _uiState.value = LearningUiState.Error("오디오 다운로드 실패")
-                    }
-                    .collect { file ->
-                        playAudio(file)
-                    }
-            } catch (e: Exception) {
-                _uiState.value = LearningUiState.Error("오디오 처리 중 오류 발생")
-            }
+    private suspend fun downloadAudio(text: String) {
+        try {
+            downloadAudioUseCase(text)
+                .catch {
+                    _uiState.value = LearningUiState.Error("오디오 다운로드 실패")
+                }
+                .collect { file ->
+                    playAudio(file)
+                }
+        } catch (e: Exception) {
+            _uiState.value = LearningUiState.Error("오디오 처리 중 오류 발생")
         }
     }
 

--- a/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
+++ b/presentation/learning/src/main/java/com/saegil/learning/learning/LearningViewModel.kt
@@ -111,6 +111,15 @@ class LearningViewModel @Inject constructor(
         if (_uiState.value == LearningUiState.isRecording) {
             stopRecording()
         }
+        stopPlaying()
+    }
+
+    private fun stopPlaying() {
+        mediaPlayer?.apply {
+            stop()
+            release()
+        }
+        mediaPlayer = null
     }
 
     private suspend fun downloadAudio(text: String) {


### PR DESCRIPTION
## ⭐️ 변경된 내용
solved #59 
+ 텍스트랑 음성 출력 싱크를 맞췄습니다.
+ 기존에는 ai 응답을 state 변경을 먼저 한 후에 음성 변환을 하고 그것을 출력하는 방식이였는데
응답을 받고 그것을 음성 변환하는 것이 끝날 때까지 연산을 멈추도록 `suspend` 함수로 변경하고 변환후에 state를 변경하도록 수정했습니다,
+ 그리고 화면 이탈하면 음성 출력 중단하도록 했습니다.

## 📌 이 부분은 꼭 봐주세요! (Optional)



## 🏞️ 스크린샷 (Optional)

https://github.com/user-attachments/assets/6e6998d9-4258-43e1-98b4-3c1f16f30c9f

